### PR TITLE
Stop generating autodocs

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -2,8 +2,6 @@
 # Makefile.am for devtools/devtools/skeletons/config/doc
 #
 
-SUBDIRS = autodocs
-
 htmldir = $(docdir)
 
 doc_DATA = README.expert

--- a/doc/autodocs/Makefile.am
+++ b/doc/autodocs/Makefile.am
@@ -1,3 +1,0 @@
-# Makefile.am for YCP module .../doc/autodocs
-
-include $(top_srcdir)/autodocs-ycp.ami

--- a/package/yast2-product-creator.changes
+++ b/package/yast2-product-creator.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon Jun  6 07:25:59 UTC 2016 - igonzalezsosa@suse.com
+
+- Stop generating autodocs
+
+-------------------------------------------------------------------
 Thu Dec 11 08:52:49 CET 2014 - jsuchome@suse.cz
 
 - require latest version of kiwi-schema: 6.2 (bnc#909280)

--- a/package/yast2-product-creator.changes
+++ b/package/yast2-product-creator.changes
@@ -1,7 +1,8 @@
 -------------------------------------------------------------------
 Mon Jun  6 07:25:59 UTC 2016 - igonzalezsosa@suse.com
 
-- Stop generating autodocs
+- Stop generating autodocs (fate#320356)
+- 3.1.8
 
 -------------------------------------------------------------------
 Thu Dec 11 08:52:49 CET 2014 - jsuchome@suse.cz

--- a/package/yast2-product-creator.spec
+++ b/package/yast2-product-creator.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-product-creator
-Version:        3.1.7
+Version:        3.1.8
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
No devel-doc package was generated and doc/autodocs is empty anyway, so I'm disabling autodocs generation.