### PR TITLE
Do not use UI in command line mode (bsc#1071129)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.yardoc
+coverage
+doc/autodocs
 Makefile
 Makefile.am
 Makefile.in
@@ -24,7 +27,10 @@ stamp-h*
 Makefile.am.common
 *.ami
 *.bz2
-.dep
 tmp.*
 *.log
-*.ybc
+/testsuite/config/
+/testsuite/run/
+/testsuite/*.exp
+/testsuite/*.sum
+testsuite/*.test/testsuite.exp

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,7 @@
+--no-private
+--protected
+--markup markdown
+--readme README.md
+--output-dir ./doc/autodocs
+--files *.md
+src/**/*.rb

--- a/package/yast2-product-creator.changes
+++ b/package/yast2-product-creator.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Dec 14 14:10:25 UTC 2017 - lslezak@suse.cz
+
+- Fixed crash when creating an image from command line
+  (bsc#1071129)
+- 3.2.1
+
+-------------------------------------------------------------------
 Wed Mar 29 07:09:03 UTC 2017 - mfilka@suse.com
 
 - bnc#1026027

--- a/package/yast2-product-creator.spec
+++ b/package/yast2-product-creator.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-product-creator
-Version:        3.2.0
+Version:        3.2.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/ProductCreator.rb
+++ b/src/modules/ProductCreator.rb
@@ -249,6 +249,8 @@ module Yast
     # Check for pending Abort press
     # @return true if pending abort
     def PollAbort
+      return false if Mode.commandline
+
       UI.PollInput == :abort
     end
 
@@ -3436,6 +3438,8 @@ module Yast
     end
 
     def ProgressDownload(percent, bps_avg, bps_current)
+      return true if Mode.commandline
+
       UI.PollInput != :abort
     end
 


### PR DESCRIPTION
- Fix for https://bugzilla.suse.com/show_bug.cgi?id=1071129
- Do not call UI functions in command line mode, it fails