### PR TITLE
Adapted package translation on the required amount of packages

### DIFF
--- a/package/yast2-product-creator.changes
+++ b/package/yast2-product-creator.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon May 25 09:34:56 CEST 2020 - schubi@suse.de
+
+- Removing incompatible packages.<language>.gz files before
+  creating the image (bsc#1165247).
+- 3.2.3
+
+-------------------------------------------------------------------
 Thu Mar 15 09:59:53 CET 2018 - schubi@suse.de
 
 - Wrong AutoYaST settings: Do not merge defined profile settings

--- a/package/yast2-product-creator.spec
+++ b/package/yast2-product-creator.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-product-creator
-Version:        3.2.2
+Version:        3.2.3
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/modules/ProductCreator.rb
+++ b/src/modules/ProductCreator.rb
@@ -3647,16 +3647,6 @@ module Yast
               )
             )
         else
-          # TODO FIXME get datadir from the source
-          ret = ret &&
-            Exec(
-              Builtins.sformat(
-                "cd '%1/%2/%3' && /usr/bin/create_package_descr -x setup/descr/EXTRA_PROV -M 3",
-                String.Quote(basedir),
-                String.Quote(subdir),
-                String.Quote(datadir)
-              )
-            )
 
           # check if the metadata are gzipped
           compressed_meta = FileUtils.Exists(
@@ -3668,6 +3658,30 @@ module Yast
             )
           )
           Builtins.y2milestone("Compressed metadata: %1", compressed_meta)
+
+          # TODO FIXME get datadir from the source
+
+          # remove the translation files, they would get out of sync with the main data
+          # and confuse libzypp (bsc#1165247)
+          ret = ret &&
+            Exec(
+              Builtins.sformat(
+                "rm %1/%2/%3/setup/descr/packages.*",
+                String.Quote(basedir),
+                String.Quote(subdir),
+                String.Quote(datadir)
+              )
+            )
+
+          ret = ret &&
+            Exec(
+              Builtins.sformat(
+                "cd '%1/%2/%3' && /usr/bin/create_package_descr -x setup/descr/EXTRA_PROV -M 3",
+                String.Quote(basedir),
+                String.Quote(subdir),
+                String.Quote(datadir)
+              )
+            )
 
           if compressed_meta
             ret = ret &&

--- a/src/modules/ProductCreator.rb
+++ b/src/modules/ProductCreator.rb
@@ -29,6 +29,7 @@
 # Representation of the configuration of product-creator.
 # Input and output routines.
 require "yast"
+require "shellwords"
 
 module Yast
   class ProductCreatorClass < Module
@@ -3667,9 +3668,9 @@ module Yast
             Exec(
               Builtins.sformat(
                 "rm %1/%2/%3/setup/descr/packages.*",
-                String.Quote(basedir),
-                String.Quote(subdir),
-                String.Quote(datadir)
+                basedir.shellescape,
+                subdir.shellescape,
+                datadir.shellescape
               )
             )
 


### PR DESCRIPTION
Problem
========

While creating a new image the suse/setup/desc/packages.\<language\>.gz files  will not be updated.
This produces an error while package installation. The package will not be found on the repo.

Solution
========
Deleting these corrupted files. So libzypp will not take it in account anymore. 